### PR TITLE
Fix CORS after backend Quarkus3 update

### DIFF
--- a/kubernetes/kaoto.yaml
+++ b/kubernetes/kaoto.yaml
@@ -56,6 +56,9 @@ spec:
             - name: port
               containerPort: 8081
               protocol: TCP
+          env:
+            - name: QUARKUS_HTTP_CORS_ORIGINS
+              value: /.*/
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: Always


### PR DESCRIPTION
CORS needs to be set after Quarkus3 update on backend https://github.com/KaotoIO/kaoto-backend/pull/695
[More info](https://github.com/KaotoIO/kaoto-backend#cors)
This is how it was working before ( all requests were accepted ) 

In the future, the operator should set Kaoto UI route in the env instead of wildcard. FeatureRequest: https://github.com/KaotoIO/kaoto-operator/issues/71